### PR TITLE
Address ruby 3.0 support

### DIFF
--- a/lib/attr_encrypted/adapters/active_record.rb
+++ b/lib/attr_encrypted/adapters/active_record.rb
@@ -62,7 +62,7 @@ if defined?(ActiveRecord::Base)
 
             if ::ActiveRecord::VERSION::STRING >= "4.1"
               define_method("#{attr}_changed?") do |options = {}|
-                attribute_changed?(attr, options)
+                attribute_changed?(attr, **options)
               end
             else
               define_method("#{attr}_changed?") do


### PR DESCRIPTION
Since Rails 7 requires minimum ruby 2.7+

This PR is intended to separation of positional and keyword arguments introduced since ruby 2.7 and it's necessary for ruby 3.0 